### PR TITLE
feat: add WAN-type-specific sensors (cellular, signal, allowance)

### DIFF
--- a/.github/workflows/hacs-validation.yaml
+++ b/.github/workflows/hacs-validation.yaml
@@ -20,3 +20,5 @@ jobs:
 
       - name: Hassfest validation
         uses: "home-assistant/actions/hassfest@1.0.0"
+        with:
+          path: "custom_components/peplink_local"

--- a/custom_components/peplink_local/__init__.py
+++ b/custom_components/peplink_local/__init__.py
@@ -204,41 +204,21 @@ class PeplinkDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if not traffic_stats:
                 raise UpdateFailed("Failed to get traffic statistics")
                 
-            # Fetch signal and allowance data per-WAN
+            # Fetch allowance data (single call returns all WANs)
             connections = wan_status.get("connection", [])
-            signal_tasks = []
-            allowance_tasks = []
-            signal_wan_indices = []
-            allowance_wan_indices = []
-
-            for i, conn in enumerate(connections):
-                if not conn.get("enable") or not conn.get("message", "").startswith("Connected"):
-                    continue
-                conn_id = conn.get("id")
-                if not conn_id:
-                    continue
-                # Signal for cellular/WiFi WANs
-                if "cellular" in conn or "wifi" in conn or "wireless" in conn:
-                    signal_tasks.append(self.api.get_wan_signal(int(conn_id)))
-                    signal_wan_indices.append(i)
-                # Allowance for WANs with monitoring enabled
-                bam = conn.get("bandwidthAllowanceMonitor", {})
-                if bam.get("enable"):
-                    allowance_tasks.append(self.api.get_wan_allowance(int(conn_id)))
-                    allowance_wan_indices.append(i)
-
-            # Fetch in parallel, don't fail on errors
-            if signal_tasks:
-                signal_results = await asyncio.gather(*signal_tasks, return_exceptions=True)
-                for idx, result in zip(signal_wan_indices, signal_results):
-                    if isinstance(result, dict) and result:
-                        connections[idx]["signal"] = result
-
-            if allowance_tasks:
-                allowance_results = await asyncio.gather(*allowance_tasks, return_exceptions=True)
-                for idx, result in zip(allowance_wan_indices, allowance_results):
-                    if isinstance(result, dict) and result:
-                        connections[idx]["allowance"] = result
+            try:
+                allowance_data = await self.api.get_wan_allowance()
+                if allowance_data:
+                    for conn in connections:
+                        wan_id = str(conn.get("id", ""))
+                        wan_allowance = allowance_data.get(wan_id, {})
+                        # Find the active SIM's allowance (per-SIM keys are "1", "2", etc.)
+                        for sim_key, sim_data in wan_allowance.items():
+                            if isinstance(sim_data, dict) and sim_data.get("enable"):
+                                conn["allowance"] = sim_data
+                                break
+            except Exception:
+                pass  # Allowance data is optional
 
             # Update model and firmware information if available
             device_info_data = device_info.get("device_info", {})

--- a/custom_components/peplink_local/__init__.py
+++ b/custom_components/peplink_local/__init__.py
@@ -204,6 +204,42 @@ class PeplinkDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if not traffic_stats:
                 raise UpdateFailed("Failed to get traffic statistics")
                 
+            # Fetch signal and allowance data per-WAN
+            connections = wan_status.get("connection", [])
+            signal_tasks = []
+            allowance_tasks = []
+            signal_wan_indices = []
+            allowance_wan_indices = []
+
+            for i, conn in enumerate(connections):
+                if not conn.get("enable") or not conn.get("message", "").startswith("Connected"):
+                    continue
+                conn_id = conn.get("id")
+                if not conn_id:
+                    continue
+                # Signal for cellular/WiFi WANs
+                if "cellular" in conn or "wifi" in conn or "wireless" in conn:
+                    signal_tasks.append(self.api.get_wan_signal(int(conn_id)))
+                    signal_wan_indices.append(i)
+                # Allowance for WANs with monitoring enabled
+                bam = conn.get("bandwidthAllowanceMonitor", {})
+                if bam.get("enable"):
+                    allowance_tasks.append(self.api.get_wan_allowance(int(conn_id)))
+                    allowance_wan_indices.append(i)
+
+            # Fetch in parallel, don't fail on errors
+            if signal_tasks:
+                signal_results = await asyncio.gather(*signal_tasks, return_exceptions=True)
+                for idx, result in zip(signal_wan_indices, signal_results):
+                    if isinstance(result, dict) and result:
+                        connections[idx]["signal"] = result
+
+            if allowance_tasks:
+                allowance_results = await asyncio.gather(*allowance_tasks, return_exceptions=True)
+                for idx, result in zip(allowance_wan_indices, allowance_results):
+                    if isinstance(result, dict) and result:
+                        connections[idx]["allowance"] = result
+
             # Update model and firmware information if available
             device_info_data = device_info.get("device_info", {})
             if device_info_data:

--- a/custom_components/peplink_local/peplink_api.py
+++ b/custom_components/peplink_local/peplink_api.py
@@ -282,6 +282,10 @@ class PeplinkAPI:
             if func.startswith('/'):
                 func = func[1:]
             endpoint = f"/api/{func}"
+            # Append any additional parameters as query string
+            if kwargs:
+                query_string = "&".join([f"{k}={v}" for k, v in kwargs.items()])
+                endpoint = f"{endpoint}?{query_string}"
         else:
             # Use "/cgi-bin/MANGA/api.cgi?func=..." style endpoint
             # Add timestamp to prevent caching

--- a/custom_components/peplink_local/peplink_api.py
+++ b/custom_components/peplink_local/peplink_api.py
@@ -908,7 +908,33 @@ class PeplinkAPI:
         except Exception as e:
             _LOGGER.error("Error retrieving location information: %s", e)
             return {"gps": False, "type": "Unknown", "location": {}}
-            
+
+    async def get_wan_signal(self, conn_id: int) -> Dict[str, Any]:
+        """Retrieve signal details for a specific WAN connection."""
+        try:
+            response = await self._make_api_request(
+                "status.wan.connection.signal", public_api=True, id=conn_id
+            )
+            if response.get("stat") == "ok" and "response" in response:
+                return response["response"]
+            return {}
+        except Exception as e:
+            _LOGGER.debug("Signal data not available for WAN %s: %s", conn_id, e)
+            return {}
+
+    async def get_wan_allowance(self, conn_id: int) -> Dict[str, Any]:
+        """Retrieve bandwidth allowance data for a specific WAN connection."""
+        try:
+            response = await self._make_api_request(
+                "status.wan.connection.allowance", public_api=True, id=conn_id
+            )
+            if response.get("stat") == "ok" and "response" in response:
+                return response["response"]
+            return {}
+        except Exception as e:
+            _LOGGER.debug("Allowance data not available for WAN %s: %s", conn_id, e)
+            return {}
+
     async def close(self) -> None:
         """Close the session if we created it."""
         if self._own_session and self._session is not None:

--- a/custom_components/peplink_local/peplink_api.py
+++ b/custom_components/peplink_local/peplink_api.py
@@ -909,30 +909,21 @@ class PeplinkAPI:
             _LOGGER.error("Error retrieving location information: %s", e)
             return {"gps": False, "type": "Unknown", "location": {}}
 
-    async def get_wan_signal(self, conn_id: int) -> Dict[str, Any]:
-        """Retrieve signal details for a specific WAN connection."""
-        try:
-            response = await self._make_api_request(
-                "status.wan.connection.signal", public_api=True, id=conn_id
-            )
-            if response.get("stat") == "ok" and "response" in response:
-                return response["response"]
-            return {}
-        except Exception as e:
-            _LOGGER.debug("Signal data not available for WAN %s: %s", conn_id, e)
-            return {}
+    async def get_wan_allowance(self) -> Dict[str, Any]:
+        """Retrieve bandwidth allowance data for all WAN connections.
 
-    async def get_wan_allowance(self, conn_id: int) -> Dict[str, Any]:
-        """Retrieve bandwidth allowance data for a specific WAN connection."""
+        Returns the response dict keyed by WAN ID. Each WAN may contain
+        per-SIM allowance data keyed by SIM number ("1", "2", etc.).
+        """
         try:
             response = await self._make_api_request(
-                "status.wan.connection.allowance", public_api=True, id=conn_id
+                "status.wan.connection.allowance", public_api=True
             )
             if response.get("stat") == "ok" and "response" in response:
                 return response["response"]
             return {}
         except Exception as e:
-            _LOGGER.debug("Allowance data not available for WAN %s: %s", conn_id, e)
+            _LOGGER.debug("Allowance data not available: %s", e)
             return {}
 
     async def close(self) -> None:

--- a/custom_components/peplink_local/sensor.py
+++ b/custom_components/peplink_local/sensor.py
@@ -65,6 +65,30 @@ uptime_to_stable_datetime = ignore_variance(
     datetime.timedelta(minutes=1),
 )
 
+
+def _get_primary_band_field(connection: dict, *keys: str):
+    """Extract a field from the primary band of a cellular connection.
+
+    The cellular.rat array contains radio access technologies (5G, LTE, etc.)
+    with nested bands. The first RAT's first band is the primary.
+    Supports paths like ("signal", "rsrp") or ("name",).
+    """
+    try:
+        rat = connection.get("cellular", {}).get("rat", [])
+        if not rat:
+            return None
+        bands = rat[0].get("band", [])
+        if not bands:
+            return None
+        result = bands[0]
+        for key in keys:
+            result = result.get(key)
+            if result is None:
+                return None
+        return result
+    except (IndexError, AttributeError, TypeError):
+        return None
+
 SENSOR_TYPES: tuple[PeplinkSensorEntityDescription, ...] = (
     # System sensors
     PeplinkSensorEntityDescription(
@@ -280,52 +304,96 @@ SENSOR_TYPES: tuple[PeplinkSensorEntityDescription, ...] = (
         icon="mdi:signal-cellular-3",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    # Signal detail sensors (per-WAN, from status.wan.connection.signal)
     PeplinkSensorEntityDescription(
-        key="signal_rssi",
+        key="cellular_carrier",
         translation_key=None,
-        name="RSSI",
-        native_unit_of_measurement="dBm",
-        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda x: x.get("signal", {}).get("rssi"),
-        icon="mdi:signal-variant",
-    ),
-    PeplinkSensorEntityDescription(
-        key="signal_sinr",
-        translation_key=None,
-        name="SINR",
-        native_unit_of_measurement="dB",
+        name="Carrier",
+        native_unit_of_measurement=None,
         device_class=None,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=None,
+        value_fn=lambda x: x.get("cellular", {}).get("carrier", {}).get("name"),
+        icon="mdi:antenna",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda x: x.get("signal", {}).get("sinr"),
-        icon="mdi:signal-variant",
     ),
     PeplinkSensorEntityDescription(
-        key="signal_rsrp",
+        key="cellular_data_technology",
+        translation_key=None,
+        name="Data Technology",
+        native_unit_of_measurement=None,
+        device_class=None,
+        state_class=None,
+        value_fn=lambda x: x.get("cellular", {}).get("dataTechnology"),
+        icon="mdi:cellphone-wireless",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    PeplinkSensorEntityDescription(
+        key="cellular_band",
+        translation_key=None,
+        name="Band",
+        native_unit_of_measurement=None,
+        device_class=None,
+        state_class=None,
+        value_fn=lambda x: _get_primary_band_field(x, "name"),
+        icon="mdi:radio-tower",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    PeplinkSensorEntityDescription(
+        key="cellular_modem",
+        translation_key=None,
+        name="Modem",
+        native_unit_of_measurement=None,
+        device_class=None,
+        state_class=None,
+        value_fn=lambda x: x.get("cellular", {}).get("model"),
+        icon="mdi:chip",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # Signal detail sensors — extracted from cellular.rat[0].band[0].signal (primary band)
+    PeplinkSensorEntityDescription(
+        key="cellular_rsrp",
         translation_key=None,
         name="RSRP",
         native_unit_of_measurement="dBm",
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda x: x.get("signal", {}).get("rsrp"),
+        value_fn=lambda x: _get_primary_band_field(x, "signal", "rsrp"),
         icon="mdi:signal-variant",
     ),
     PeplinkSensorEntityDescription(
-        key="signal_rsrq",
+        key="cellular_sinr",
+        translation_key=None,
+        name="SINR",
+        native_unit_of_measurement="dB",
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda x: _get_primary_band_field(x, "signal", "sinr"),
+        icon="mdi:signal-variant",
+    ),
+    PeplinkSensorEntityDescription(
+        key="cellular_rsrq",
         translation_key=None,
         name="RSRQ",
         native_unit_of_measurement="dB",
         device_class=None,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda x: x.get("signal", {}).get("rsrq"),
+        value_fn=lambda x: _get_primary_band_field(x, "signal", "rsrq"),
         icon="mdi:signal-variant",
     ),
-    # Bandwidth allowance sensor (per-WAN, from status.wan.connection.allowance)
+    PeplinkSensorEntityDescription(
+        key="cellular_rssi",
+        translation_key=None,
+        name="RSSI",
+        native_unit_of_measurement="dBm",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda x: _get_primary_band_field(x, "signal", "rssi"),
+        icon="mdi:signal-variant",
+    ),
+    # Bandwidth allowance sensors (per active SIM, from status.wan.connection.allowance)
     PeplinkSensorEntityDescription(
         key="allowance_usage",
         translation_key=None,
@@ -336,6 +404,28 @@ SENSOR_TYPES: tuple[PeplinkSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda x: x.get("allowance", {}).get("usage"),
         icon="mdi:chart-donut",
+    ),
+    PeplinkSensorEntityDescription(
+        key="allowance_limit",
+        translation_key=None,
+        name="Data Limit",
+        native_unit_of_measurement="MB",
+        device_class=SensorDeviceClass.DATA_SIZE,
+        state_class=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda x: x.get("allowance", {}).get("limit"),
+        icon="mdi:chart-donut-variant",
+    ),
+    PeplinkSensorEntityDescription(
+        key="allowance_percent",
+        translation_key=None,
+        name="Data Usage Percent",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda x: x.get("allowance", {}).get("percent"),
+        icon="mdi:percent-circle",
     ),
     # GPS Location sensors
     PeplinkSensorEntityDescription(
@@ -595,13 +685,9 @@ async def async_setup_entry(
                 if wan_connection.get("wifi") or wan_connection.get("wireless"):
                     entities += _create_typed_wan_sensors("wifi_", wan_connection, coordinator, device_info, wan_id)
 
-                # Add cellular sensors if this is a cellular WAN
+                # Add cellular sensors (includes signal detail) if this is a cellular WAN
                 if wan_connection.get("cellular"):
                     entities += _create_typed_wan_sensors("cellular_", wan_connection, coordinator, device_info, wan_id)
-
-                # Add signal detail sensors if signal data was fetched
-                if wan_connection.get("signal"):
-                    entities += _create_typed_wan_sensors("signal_", wan_connection, coordinator, device_info, wan_id)
 
                 # Add allowance sensor if allowance data was fetched
                 if wan_connection.get("allowance"):

--- a/custom_components/peplink_local/sensor.py
+++ b/custom_components/peplink_local/sensor.py
@@ -599,6 +599,14 @@ async def async_setup_entry(
                 if wan_connection.get("cellular"):
                     entities += _create_typed_wan_sensors("cellular_", wan_connection, coordinator, device_info, wan_id)
 
+                # Add signal detail sensors if signal data was fetched
+                if wan_connection.get("signal"):
+                    entities += _create_typed_wan_sensors("signal_", wan_connection, coordinator, device_info, wan_id)
+
+                # Add allowance sensor if allowance data was fetched
+                if wan_connection.get("allowance"):
+                    entities += _create_typed_wan_sensors("allowance_", wan_connection, coordinator, device_info, wan_id)
+
                 # Handle uptime - if available in data
                 if "uptime" in wan_connection:
                     uptime_description = next(

--- a/custom_components/peplink_local/sensor.py
+++ b/custom_components/peplink_local/sensor.py
@@ -291,6 +291,40 @@ SENSOR_TYPES: tuple[PeplinkSensorEntityDescription, ...] = (
 )
 
 
+def _create_typed_wan_sensors(
+    prefix: str,
+    wan_connection: dict,
+    coordinator: PeplinkDataUpdateCoordinator,
+    device_info: DeviceInfo,
+    wan_id: str,
+) -> list:
+    """Create WAN sensors for a given type prefix (e.g., 'wifi_', 'cellular_')."""
+    entities = []
+    for description in SENSOR_TYPES:
+        if description.key.startswith(prefix):
+            sensor_description = PeplinkSensorEntityDescription(
+                key=description.key[len(prefix):],
+                translation_key=description.translation_key,
+                name=description.name,
+                native_unit_of_measurement=description.native_unit_of_measurement,
+                device_class=description.device_class,
+                state_class=description.state_class,
+                icon=description.icon,
+                value_fn=description.value_fn,
+                entity_category=description.entity_category,
+            )
+            entities.append(
+                PeplinkWANSensor(
+                    coordinator=coordinator,
+                    description=sensor_description,
+                    sensor_data=wan_connection,
+                    device_info=device_info,
+                    wan_id=wan_id,
+                )
+            )
+    return entities
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -462,8 +496,9 @@ async def async_setup_entry(
                             native_unit_of_measurement=description.native_unit_of_measurement,
                             device_class=description.device_class,
                             state_class=description.state_class,
-                            icon=description.icon,  # Use the icon from the original description
+                            icon=description.icon,
                             value_fn=description.value_fn,
+                            entity_category=description.entity_category,
                         )
                         entities.append(
                             PeplinkWANSensor(

--- a/custom_components/peplink_local/sensor.py
+++ b/custom_components/peplink_local/sensor.py
@@ -257,6 +257,86 @@ SENSOR_TYPES: tuple[PeplinkSensorEntityDescription, ...] = (
         icon="mdi:wifi-settings",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # Cellular specific sensors
+    PeplinkSensorEntityDescription(
+        key="cellular_mobile_type",
+        translation_key=None,
+        name="Mobile Technology",
+        native_unit_of_measurement=None,
+        device_class=None,
+        state_class=None,
+        value_fn=lambda x: x.get("cellular", {}).get("mobileType"),
+        icon="mdi:cellphone-wireless",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    PeplinkSensorEntityDescription(
+        key="cellular_signal_level",
+        translation_key=None,
+        name="Signal Level",
+        native_unit_of_measurement=None,
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda x: x.get("cellular", {}).get("signalLevel"),
+        icon="mdi:signal-cellular-3",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # Signal detail sensors (per-WAN, from status.wan.connection.signal)
+    PeplinkSensorEntityDescription(
+        key="signal_rssi",
+        translation_key=None,
+        name="RSSI",
+        native_unit_of_measurement="dBm",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda x: x.get("signal", {}).get("rssi"),
+        icon="mdi:signal-variant",
+    ),
+    PeplinkSensorEntityDescription(
+        key="signal_sinr",
+        translation_key=None,
+        name="SINR",
+        native_unit_of_measurement="dB",
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda x: x.get("signal", {}).get("sinr"),
+        icon="mdi:signal-variant",
+    ),
+    PeplinkSensorEntityDescription(
+        key="signal_rsrp",
+        translation_key=None,
+        name="RSRP",
+        native_unit_of_measurement="dBm",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda x: x.get("signal", {}).get("rsrp"),
+        icon="mdi:signal-variant",
+    ),
+    PeplinkSensorEntityDescription(
+        key="signal_rsrq",
+        translation_key=None,
+        name="RSRQ",
+        native_unit_of_measurement="dB",
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda x: x.get("signal", {}).get("rsrq"),
+        icon="mdi:signal-variant",
+    ),
+    # Bandwidth allowance sensor (per-WAN, from status.wan.connection.allowance)
+    PeplinkSensorEntityDescription(
+        key="allowance_usage",
+        translation_key=None,
+        name="Data Usage",
+        native_unit_of_measurement="MB",
+        device_class=SensorDeviceClass.DATA_SIZE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda x: x.get("allowance", {}).get("usage"),
+        icon="mdi:chart-donut",
+    ),
     # GPS Location sensors
     PeplinkSensorEntityDescription(
         key="heading",
@@ -511,6 +591,14 @@ async def async_setup_entry(
                             )
                         )
                         
+                # Add WiFi sensors if this is a WiFi WAN
+                if wan_connection.get("wifi") or wan_connection.get("wireless"):
+                    entities += _create_typed_wan_sensors("wifi_", wan_connection, coordinator, device_info, wan_id)
+
+                # Add cellular sensors if this is a cellular WAN
+                if wan_connection.get("cellular"):
+                    entities += _create_typed_wan_sensors("cellular_", wan_connection, coordinator, device_info, wan_id)
+
                 # Handle uptime - if available in data
                 if "uptime" in wan_connection:
                     uptime_description = next(

--- a/custom_components/peplink_local/sensor.py
+++ b/custom_components/peplink_local/sensor.py
@@ -449,8 +449,9 @@ async def async_setup_entry(
                         native_unit_of_measurement=description.native_unit_of_measurement,
                         device_class=description.device_class,
                         state_class=description.state_class,
-                        icon=description.icon,  # Use the icon from the original description
+                        icon=description.icon,
                         value_fn=description.value_fn,
+                        entity_category=description.entity_category,
                     )
                     entities.append(
                         PeplinkWANSensor(
@@ -525,6 +526,7 @@ async def async_setup_entry(
                             state_class=uptime_description.state_class,
                             icon=uptime_description.icon,
                             value_fn=uptime_description.value_fn,
+                            entity_category=uptime_description.entity_category,
                         )
                         entities.append(
                             PeplinkWANSensor(

--- a/tests/run_api_test.sh
+++ b/tests/run_api_test.sh
@@ -13,9 +13,17 @@ cd "$(dirname "$0")/.."
 # Make the test script executable
 chmod +x "./tests/standalone_test.py"
 
-# Install required dependencies
-echo "Installing required dependencies from requirements.txt"
-pip install -r requirements.txt
+# Set up virtual environment
+VENV_DIR=".venv"
+if [ ! -d "$VENV_DIR" ]; then
+    echo "Creating virtual environment..."
+    python3 -m venv "$VENV_DIR"
+fi
+
+# Activate and install dependencies
+source "$VENV_DIR/bin/activate"
+echo "Installing required dependencies..."
+pip install -q aiohttp python-dotenv
 
 # Check if .env file exists, if not, copy from example
 if [ ! -f ".env" ] && [ -f ".env.example" ]; then

--- a/tests/standalone_test.py
+++ b/tests/standalone_test.py
@@ -34,10 +34,16 @@ except ImportError:
     subprocess.check_call([sys.executable, "-m", "pip", "install", "python-dotenv"])
     from dotenv import load_dotenv
 
-# Configure logging
+# Configure logging — write to both stdout and a log file (overwritten each run)
+_log_file = Path(__file__).parent / "output" / "api_test.log"
+_log_file.parent.mkdir(parents=True, exist_ok=True)
 logging.basicConfig(
     level=logging.DEBUG,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler(_log_file, mode='w'),
+    ],
 )
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/standalone_test.py
+++ b/tests/standalone_test.py
@@ -189,7 +189,70 @@ async def test_api(router_ip, username, password, verify_ssl=False):
             _LOGGER.error("Error during wan_status test: %s", e)
             test_results["wan_status"] = f"FAILED: {str(e)}"
             test_context = {"wan_interfaces": []}
-        
+
+        # 5a. Raw WAN status dump (captures cellular/wifi sub-objects not visible after processing)
+        _LOGGER.info("Fetching raw WAN status via direct API call...")
+        try:
+            wan_status_raw = await api._api_request("/api/status.wan.connection")
+            _LOGGER.info("Raw WAN status: %s", json.dumps(wan_status_raw, indent=2))
+
+            with open(output_dir / "wan_status_raw.json", "w") as f:
+                json.dump(wan_status_raw, f, indent=2)
+
+            test_results["wan_status_raw"] = "PASSED"
+        except Exception as e:
+            _LOGGER.error("Error during raw WAN status dump: %s", e)
+            test_results["wan_status_raw"] = f"FAILED: {str(e)}"
+
+        # 5b. Signal endpoint exploration (per-WAN)
+        wan_interfaces = test_context.get("wan_interfaces", [])
+        if wan_interfaces:
+            _LOGGER.info("Exploring signal endpoint for %d WAN(s)...", len(wan_interfaces))
+            for wan_id in wan_interfaces:
+                test_key = f"wan_signal_{wan_id}"
+                try:
+                    signal_data = await api._api_request(
+                        f"/api/status.wan.connection.signal?id={wan_id}"
+                    )
+                    _LOGGER.info(
+                        "Signal data for WAN %s: %s",
+                        wan_id, json.dumps(signal_data, indent=2)
+                    )
+
+                    with open(output_dir / f"wan_signal_{wan_id}.json", "w") as f:
+                        json.dump(signal_data, f, indent=2)
+
+                    test_results[test_key] = "PASSED"
+                except Exception as e:
+                    _LOGGER.error("Error fetching signal for WAN %s: %s", wan_id, e)
+                    test_results[test_key] = f"FAILED: {str(e)}"
+        else:
+            _LOGGER.warning("No WAN interfaces found — skipping signal endpoint exploration")
+
+        # 5c. Allowance endpoint exploration (per-WAN)
+        if wan_interfaces:
+            _LOGGER.info("Exploring allowance endpoint for %d WAN(s)...", len(wan_interfaces))
+            for wan_id in wan_interfaces:
+                test_key = f"wan_allowance_{wan_id}"
+                try:
+                    allowance_data = await api._api_request(
+                        f"/api/status.wan.connection.allowance?id={wan_id}"
+                    )
+                    _LOGGER.info(
+                        "Allowance data for WAN %s: %s",
+                        wan_id, json.dumps(allowance_data, indent=2)
+                    )
+
+                    with open(output_dir / f"wan_allowance_{wan_id}.json", "w") as f:
+                        json.dump(allowance_data, f, indent=2)
+
+                    test_results[test_key] = "PASSED"
+                except Exception as e:
+                    _LOGGER.error("Error fetching allowance for WAN %s: %s", wan_id, e)
+                    test_results[test_key] = f"FAILED: {str(e)}"
+        else:
+            _LOGGER.warning("No WAN interfaces found — skipping allowance endpoint exploration")
+
         # 6. Client information
         _LOGGER.info("Fetching client information...")
         try:

--- a/tests/standalone_test.py
+++ b/tests/standalone_test.py
@@ -210,54 +210,33 @@ async def test_api(router_ip, username, password, verify_ssl=False):
             _LOGGER.error("Error during raw WAN status dump: %s", e)
             test_results["wan_status_raw"] = f"FAILED: {str(e)}"
 
-        # 5b. Signal endpoint exploration (per-WAN)
-        wan_interfaces = test_context.get("wan_interfaces", [])
-        if wan_interfaces:
-            _LOGGER.info("Exploring signal endpoint for %d WAN(s)...", len(wan_interfaces))
-            for wan_id in wan_interfaces:
-                test_key = f"wan_signal_{wan_id}"
-                try:
-                    signal_data = await api._api_request(
-                        f"/api/status.wan.connection.signal?id={wan_id}"
-                    )
-                    _LOGGER.info(
-                        "Signal data for WAN %s: %s",
-                        wan_id, json.dumps(signal_data, indent=2)
-                    )
+        # 5b. Signal endpoint exploration (single call returns all WANs)
+        _LOGGER.info("Exploring signal endpoint...")
+        try:
+            signal_data = await api._api_request("/api/status.wan.connection.signal")
+            _LOGGER.info("Signal data: %s", json.dumps(signal_data, indent=2))
 
-                    with open(output_dir / f"wan_signal_{wan_id}.json", "w") as f:
-                        json.dump(signal_data, f, indent=2)
+            with open(output_dir / "wan_signal.json", "w") as f:
+                json.dump(signal_data, f, indent=2)
 
-                    test_results[test_key] = "PASSED"
-                except Exception as e:
-                    _LOGGER.error("Error fetching signal for WAN %s: %s", wan_id, e)
-                    test_results[test_key] = f"FAILED: {str(e)}"
-        else:
-            _LOGGER.warning("No WAN interfaces found — skipping signal endpoint exploration")
+            test_results["wan_signal"] = "PASSED"
+        except Exception as e:
+            _LOGGER.error("Error fetching signal data: %s", e)
+            test_results["wan_signal"] = f"FAILED: {str(e)}"
 
-        # 5c. Allowance endpoint exploration (per-WAN)
-        if wan_interfaces:
-            _LOGGER.info("Exploring allowance endpoint for %d WAN(s)...", len(wan_interfaces))
-            for wan_id in wan_interfaces:
-                test_key = f"wan_allowance_{wan_id}"
-                try:
-                    allowance_data = await api._api_request(
-                        f"/api/status.wan.connection.allowance?id={wan_id}"
-                    )
-                    _LOGGER.info(
-                        "Allowance data for WAN %s: %s",
-                        wan_id, json.dumps(allowance_data, indent=2)
-                    )
+        # 5c. Allowance endpoint exploration (single call returns all WANs)
+        _LOGGER.info("Exploring allowance endpoint...")
+        try:
+            allowance_data = await api._api_request("/api/status.wan.connection.allowance")
+            _LOGGER.info("Allowance data: %s", json.dumps(allowance_data, indent=2))
 
-                    with open(output_dir / f"wan_allowance_{wan_id}.json", "w") as f:
-                        json.dump(allowance_data, f, indent=2)
+            with open(output_dir / "wan_allowance.json", "w") as f:
+                json.dump(allowance_data, f, indent=2)
 
-                    test_results[test_key] = "PASSED"
-                except Exception as e:
-                    _LOGGER.error("Error fetching allowance for WAN %s: %s", wan_id, e)
-                    test_results[test_key] = f"FAILED: {str(e)}"
-        else:
-            _LOGGER.warning("No WAN interfaces found — skipping allowance endpoint exploration")
+            test_results["wan_allowance"] = "PASSED"
+        except Exception as e:
+            _LOGGER.error("Error fetching allowance data: %s", e)
+            test_results["wan_allowance"] = f"FAILED: {str(e)}"
 
         # 6. Client information
         _LOGGER.info("Fetching client information...")


### PR DESCRIPTION
## What

Adds cellular-specific sensors, signal detail metrics, and bandwidth allowance tracking for Peplink routers. Also fixes dead WiFi sensor code and an entity_category copy bug.

## Why

The integration only exposed metrics common to all WAN types (download/upload, IP, uptime). Cellular WANs have rich signal data, carrier info, and data usage tracking that was invisible — users resorted to hardcoded REST configs to get this data.

## How

**Cellular sensors** — extracted from the `cellular` (Gobi_Obj) sub-object already present in `wan_status`:
- Mobile Technology (5G, LTE, etc.), Signal Level (0-5), Carrier, Data Technology (5G NSA), Band, Modem
- RSRP, SINR, RSRQ, RSSI from `cellular.rat[0].band[0].signal` (primary band)

**Bandwidth allowance** — new `get_wan_allowance()` API method calling `status.wan.connection.allowance` once per poll cycle. Parses per-WAN/per-SIM structure to find the active SIM's data:
- Data Usage (MB), Data Limit (MB), Data Usage Percent (%)

**WiFi sensor fix** — existing `wifi_*` SENSOR_TYPES were defined but never instantiated due to key-prefix filtering bug. Now created conditionally when `wifi` or `wireless` sub-object exists.

**Foundation improvements:**
- `_format_api_url` now supports query params for public API endpoints
- `_create_typed_wan_sensors` helper eliminates duplicated sensor copy-and-create pattern
- `entity_category` copy bug fixed across all 4 sensor description copy locations

**API discovery tooling** — standalone test updated to call `status.wan.connection.signal` and `status.wan.connection.allowance` endpoints, saving raw responses for analysis. Uses venv. Writes log to `tests/output/api_test.log`.

## Testing

- Ran `tests/run_api_test.sh` against a live Peplink MAX BR1 Pro 5G (firmware 8.5.2) — 12/12 tests pass
- Confirmed cellular object fields match: `mobileType: "5G"`, `signalLevel: 5`, `carrier.name: "Verizon Wireless"`, `dataTechnology: "5G NSA"`, `rat[0].band[0].signal.rsrp: -94`
- Confirmed allowance data: `usage: 42791 MB`, `limit: 51200 MB`, `percent: 83%`
- All Python files pass syntax check
- Note: RSSI sensor will show unavailable on 5G (not a 5G metric) — works on LTE

## Notes

- Signal data is already in `cellular.rat` from `status.wan` — no separate signal endpoint call needed
- Allowance endpoint ignores the `id` parameter and returns all WANs in one response
- Both endpoints are marked as beta by Peplink (`"notice": {"status": "beta"}`)
- WiFi sensors won't trigger on disconnected/scanning WiFi WANs (no `wifi` sub-object present) — correct behavior