### PR TITLE
Add fork warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> **WARNING: This is NOT the official repository.**
+> This is a personal fork. The original project lives at
+> **[weirded/ha-peplink-local](https://github.com/weirded/ha-peplink-local)**.
+> Please report issues and submit pull requests there.
+
 # Home Assistant Peplink Local Integration
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)


### PR DESCRIPTION
## What
Adds a visible blockquote warning at the top of the README indicating this is a personal fork.

## Why
Users arriving at this repo should be directed to the original upstream repository ([weirded/ha-peplink-local](https://github.com/weirded/ha-peplink-local)) for issues, PRs, and the canonical source of truth.

## How
Prepends a `>` blockquote warning banner above the `# Home Assistant Peplink Local Integration` heading with a link to the upstream repo.

## Testing
Visual — verified the markdown renders correctly with the warning above the title.