### PR TITLE
feat(button): add router action buttons

### DIFF
--- a/custom_components/peplink_local/__init__.py
+++ b/custom_components/peplink_local/__init__.py
@@ -32,7 +32,7 @@ from .peplink_api import PeplinkAPI, PeplinkAuthFailed
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.BINARY_SENSOR]
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 

--- a/custom_components/peplink_local/button.py
+++ b/custom_components/peplink_local/button.py
@@ -1,0 +1,156 @@
+"""Support for Peplink action buttons."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import PeplinkDataUpdateCoordinator
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Peplink button entities."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    api = hass.data[DOMAIN][config_entry.entry_id]["api"]
+
+    entities: list[ButtonEntity] = []
+
+    # Router reboot button (main device)
+    entities.append(PeplinkRebootButton(coordinator, api))
+
+    # Per-WAN cellular buttons
+    wan_status = coordinator.data.get("wan_status", {})
+    wan_connections = wan_status.get("connection", [])
+
+    for connection in wan_connections:
+        if connection.get("cellular"):
+            wan_id = str(connection.get("id", ""))
+            wan_name = connection.get("name", f"WAN {wan_id}")
+
+            wan_device_info = DeviceInfo(
+                identifiers={(DOMAIN, f"{config_entry.entry_id}_wan{wan_id}")},
+                manufacturer="Peplink",
+                model="WAN Connection",
+                name=f"{coordinator.device_name or 'Peplink'} WAN{wan_id}",
+                via_device=(DOMAIN, config_entry.entry_id),
+            )
+
+            entities.append(
+                PeplinkCellularResetButton(coordinator, api, wan_id, wan_device_info)
+            )
+            entities.append(
+                PeplinkCellularRescanButton(coordinator, api, wan_id, wan_device_info)
+            )
+
+    async_add_entities(entities)
+
+
+class PeplinkRebootButton(ButtonEntity):
+    """Button to reboot the Peplink router."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Reboot Router"
+    _attr_device_class = ButtonDeviceClass.RESTART
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: PeplinkDataUpdateCoordinator,
+        api,
+    ) -> None:
+        """Initialize the reboot button."""
+        self._api = api
+        self._attr_unique_id = (
+            f"{coordinator.device_name or coordinator.host}_reboot_router"
+        )
+
+        device_name = coordinator.device_name or f"Peplink {coordinator.host}"
+        model_string = coordinator.model or "Router"
+        if coordinator.product_code and coordinator.hardware_revision:
+            model_string = f"{model_string} ({coordinator.product_code} HW {coordinator.hardware_revision})"
+        elif coordinator.product_code:
+            model_string = f"{model_string} ({coordinator.product_code})"
+        elif coordinator.hardware_revision:
+            model_string = f"{model_string} (HW {coordinator.hardware_revision})"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
+            manufacturer="Peplink",
+            model=model_string,
+            name=device_name,
+            sw_version=coordinator.firmware,
+        )
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        _LOGGER.info("Rebooting Peplink router")
+        await self._api.reboot_router()
+
+
+class PeplinkCellularResetButton(ButtonEntity):
+    """Button to reset a cellular module on a specific WAN."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Reset Cellular Module"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:cellphone-cog"
+
+    def __init__(
+        self,
+        coordinator: PeplinkDataUpdateCoordinator,
+        api,
+        wan_id: str,
+        device_info: DeviceInfo,
+    ) -> None:
+        """Initialize the cellular reset button."""
+        self._api = api
+        self._wan_id = wan_id
+        self._attr_unique_id = (
+            f"{coordinator.device_name or coordinator.host}_wan{wan_id}_reset_cellular_module"
+        )
+        self._attr_device_info = device_info
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        _LOGGER.info("Resetting cellular module on WAN %s", self._wan_id)
+        await self._api.reset_cellular_module(self._wan_id)
+
+
+class PeplinkCellularRescanButton(ButtonEntity):
+    """Button to rescan cellular network on a specific WAN."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Rescan Cellular Network"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:cellphone-search"
+
+    def __init__(
+        self,
+        coordinator: PeplinkDataUpdateCoordinator,
+        api,
+        wan_id: str,
+        device_info: DeviceInfo,
+    ) -> None:
+        """Initialize the cellular rescan button."""
+        self._api = api
+        self._wan_id = wan_id
+        self._attr_unique_id = (
+            f"{coordinator.device_name or coordinator.host}_wan{wan_id}_rescan_cellular_network"
+        )
+        self._attr_device_info = device_info
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        _LOGGER.info("Rescanning cellular network on WAN %s", self._wan_id)
+        await self._api.rescan_cellular_network(self._wan_id)

--- a/custom_components/peplink_local/peplink_api.py
+++ b/custom_components/peplink_local/peplink_api.py
@@ -926,6 +926,42 @@ class PeplinkAPI:
             _LOGGER.debug("Allowance data not available: %s", e)
             return {}
 
+    async def reboot_router(self) -> None:
+        """Reboot the router."""
+        response = await self._make_api_request(
+            "cmd.system.reboot", public_api=True, method="POST"
+        )
+        if response.get("stat") != "ok":
+            raise Exception(
+                f"Reboot failed: {response.get('message', 'Unknown error')}"
+            )
+
+    async def reset_cellular_module(self, conn_id: str) -> None:
+        """Reset the cellular module for a specific WAN connection."""
+        response = await self._make_api_request(
+            "cmd.cellularModule.reset",
+            public_api=True,
+            method="POST",
+            data={"connId": conn_id},
+        )
+        if response.get("stat") != "ok":
+            raise Exception(
+                f"Cellular reset failed: {response.get('message', 'Unknown error')}"
+            )
+
+    async def rescan_cellular_network(self, conn_id: str) -> None:
+        """Rescan the cellular network for a specific WAN connection."""
+        response = await self._make_api_request(
+            "cmd.cellularModule.rescanNetwork",
+            public_api=True,
+            method="POST",
+            data={"connId": conn_id},
+        )
+        if response.get("stat") != "ok":
+            raise Exception(
+                f"Cellular rescan failed: {response.get('message', 'Unknown error')}"
+            )
+
     async def close(self) -> None:
         """Close the session if we created it."""
         if self._own_session and self._session is not None:


### PR DESCRIPTION
## What

Add button entities for triggering router maintenance commands from the HA dashboard:
- **Reboot Router** — single button on main router device (`/api/cmd.system.reboot`)
- **Reset Cellular Module** — per cellular WAN button (`/api/cmd.cellularModule.reset`)
- **Rescan Cellular Network** — per cellular WAN button (`/api/cmd.cellularModule.rescanNetwork`)

## Why

These actions were available in the old HA REST command configuration but were never ported to the custom integration. For a mobile/van setup with cellular WANs, being able to reset a modem or rescan networks from the dashboard is essential when connectivity degrades.

## How

- **`peplink_api.py`** — 3 new async methods (`reboot_router`, `reset_cellular_module`, `rescan_cellular_network`) using existing `_make_api_request` with official API endpoints
- **`button.py`** (new) — Button platform with 3 entity classes. Cellular buttons are dynamically created per WAN that has a `cellular` key in its connection data, matching the detection logic in `sensor.py`
- **`__init__.py`** — Added `Platform.BUTTON` to the PLATFORMS list

Cellular buttons appear under WAN sub-devices (same device grouping as existing sensors). Reboot button appears under the main router device.

## Testing

Not tested against a live router in this PR. The code follows established patterns from the existing sensor and binary_sensor platforms. Syntax verified via `ast.parse()`.

To test manually:
1. Install the integration on a Peplink router with cellular WANs
2. Verify button entities appear in HA under the correct devices
3. Press each button and confirm the router responds (check router logs)

## Rollback Plan

- `git revert <merge-commit-sha>` to undo
- No database migrations in this change
- No env vars or config changes introduced
- No external service integrations affected

## Verification

- Button entities appear under Devices in HA after reload
- Reboot button is under the main router device with restart icon
- Cellular reset/rescan buttons appear under each cellular WAN sub-device
- Pressing buttons triggers the corresponding API calls (visible in HA logs at debug level)

## Notes

- The `cmd.system.reboot` endpoint is undocumented in the Peplink API 8.1.1 PDF but was verified working in the prior REST command config
- HA button entities fire immediately on press — for confirmation UX, use `tap_action: confirmation` in dashboard card config