### PR TITLE
fix(button): send connId as integer for cellular API commands

### DIFF
--- a/custom_components/peplink_local/peplink_api.py
+++ b/custom_components/peplink_local/peplink_api.py
@@ -942,7 +942,7 @@ class PeplinkAPI:
             "cmd.cellularModule.reset",
             public_api=True,
             method="POST",
-            data={"connId": conn_id},
+            data={"connId": int(conn_id)},
         )
         if response.get("stat") != "ok":
             raise Exception(
@@ -955,7 +955,7 @@ class PeplinkAPI:
             "cmd.cellularModule.rescanNetwork",
             public_api=True,
             method="POST",
-            data={"connId": conn_id},
+            data={"connId": int(conn_id)},
         )
         if response.get("stat") != "ok":
             raise Exception(


### PR DESCRIPTION
## What

Fix cellular reset and rescan buttons sending `connId` as a string (`"2"`) instead of an integer (`2`).

## Why

The Peplink API specifies `connId` as type `Number`. The router rejects string values with `"Operation failed!"`. The cURL examples in the API docs confusingly show string values, but the router is strict about the type.

## How

Changed `data={"connId": conn_id}` to `data={"connId": int(conn_id)}` in both `reset_cellular_module()` and `rescan_cellular_network()`.