### PR TITLE
feat(sensor): add connected clients sensor with live client list

### DIFF
--- a/custom_components/peplink_local/lovelace/peplink-card.yaml
+++ b/custom_components/peplink_local/lovelace/peplink-card.yaml
@@ -1,0 +1,13 @@
+type: markdown
+title: Connected Clients
+content: >
+  {% set clients = state_attr('sensor.peplink_connected_clients', 'clients') %}
+  {% if clients and clients | length > 0 %}
+  | Name | IP | Connection | RSSI |
+  |------|-----|-----------|------|
+  {% for c in clients %}
+  | {{ c.name or 'Unknown' }} | {{ c.ip or '—' }} | {{ c.connection or '—' }} | {{ c.rssi if c.rssi is not none else '—' }} |
+  {% endfor %}
+  {% else %}
+  *No clients connected*
+  {% endif %}

--- a/custom_components/peplink_local/sensor.py
+++ b/custom_components/peplink_local/sensor.py
@@ -743,6 +743,14 @@ async def async_setup_entry(
     else:
         _LOGGER.debug("Router does not have GPS capability - skipping GPS sensors")
 
+    # Add connected clients sensor
+    entities.append(
+        PeplinkConnectedClientsSensor(
+            coordinator=coordinator,
+            config_entry_id=config_entry.entry_id,
+        )
+    )
+
     # Add all entities
     async_add_entities(entities)
 
@@ -958,6 +966,75 @@ class PeplinkWANSensor(CoordinatorEntity, SensorEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return entity specific state attributes."""
         return self._extra_attrs
+
+
+class PeplinkConnectedClientsSensor(CoordinatorEntity, SensorEntity):
+    """Sensor reporting the live count and list of connected network clients."""
+
+    _attr_has_entity_name = True
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:devices"
+
+    def __init__(
+        self,
+        coordinator: PeplinkDataUpdateCoordinator,
+        config_entry_id: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._config_entry_id = config_entry_id
+        self._attr_unique_id = f"{config_entry_id}_connected_clients"
+        self._attr_name = "Connected Clients"
+
+        device_name = coordinator.device_name or f"Peplink {coordinator.host}"
+        model_string = coordinator.model or "Router"
+        if coordinator.product_code and coordinator.hardware_revision:
+            model_string = f"{model_string} ({coordinator.product_code} HW {coordinator.hardware_revision})"
+        elif coordinator.product_code:
+            model_string = f"{model_string} ({coordinator.product_code})"
+        elif coordinator.hardware_revision:
+            model_string = f"{model_string} (HW {coordinator.hardware_revision})"
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, config_entry_id)},
+            manufacturer="Peplink",
+            model=model_string,
+            name=device_name,
+            sw_version=coordinator.firmware,
+        )
+
+    def _get_connected_clients(self) -> list[dict]:
+        """Return only clients with connected == True from coordinator data."""
+        all_clients = (
+            self.coordinator.data.get("clients", {}).get("client", [])
+            if self.coordinator.data
+            else []
+        )
+        return [c for c in all_clients if c.get("connected")]
+
+    @property
+    def native_value(self) -> int:
+        """Return the count of connected clients."""
+        return len(self._get_connected_clients())
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return per-client details as the 'clients' attribute."""
+        clients = []
+        for c in self._get_connected_clients():
+            conn_type = c.get("connectionType", "unknown")
+            if conn_type == "wireless":
+                connection = c.get("essid") or "wireless"
+            else:
+                connection = conn_type
+            clients.append({
+                "name": c.get("name"),
+                "ip": c.get("ip"),
+                "mac": c.get("mac"),
+                "connection": connection,
+                "rssi": c.get("rssi"),
+            })
+        return {"clients": clients}
 
 
 def _translate_wan_type(wan_type: str) -> str:


### PR DESCRIPTION
## What

Adds `sensor.peplink_connected_clients` — a new HA sensor entity that exposes a live snapshot of currently connected network clients at each coordinator poll cycle.

- **State**: integer count of clients where `connected == True`
- **Attribute `clients`**: list of `{name, ip, mac, connection, rssi}` dicts sourced from the coordinator's already-polled `/api/status.client` data (no new API calls)
- Adds `custom_components/peplink_local/lovelace/peplink-card.yaml` — a Lovelace markdown card template that renders the client list directly from sensor attributes

## Why

`device_tracker` entities use persistent MAC-based identity, which accumulates ghost "unavailable" entries over time and breaks when clients use MAC randomization. This sensor provides a clean live snapshot: whatever the router reports at each poll cycle, no history, no MAC fingerprinting. The existing `device_tracker` entities are untouched — this is purely additive.

## How

- New `PeplinkConnectedClientsSensor(CoordinatorEntity, SensorEntity)` class in `sensor.py`, registered in `async_setup_entry` alongside existing sensors
- `_get_connected_clients()` filters `coordinator.data["clients"]["client"]` to `connected == True`, used consistently by both `native_value` and `extra_state_attributes` so state and attribute list always agree
- `connection` field derives the SSID string for wireless clients (matching the existing `_derive_connection` logic in `device_tracker.py`), falls back to `connectionType` or `"unknown"`
- Lovelace card uses `state_attr('sensor.peplink_connected_clients', 'clients')` and renders a markdown table; shows `*No clients connected*` when the list is empty

## Testing

Not covered by automated tests (the integration has no unit test suite). Manual verification steps are in the Verification section below.

## Rollback Plan

- **Git revert**: `git revert <merge-sha>` then push to `my-main`
- **HA effect**: after revert and HA restart, `sensor.peplink_connected_clients` will disappear from the entity registry; any dashboards using it will show unavailable
- **No database migrations** in this change
- **No environment variables or config entries** added

## Verification

**Change works:**
1. Install updated integration via HACS (or copy to `custom_components/`)
2. Restart Home Assistant
3. Confirm `sensor.peplink_connected_clients` appears under the Peplink device in Settings → Devices & Services
4. Confirm sensor state equals the number of devices currently visible on the router's client list
5. Add the card from `lovelace/peplink-card.yaml` to a dashboard and confirm it renders one row per connected client with name, IP, connection, and RSSI

**Rollback verified:**
1. Revert the merge commit and restart HA
2. Confirm `sensor.peplink_connected_clients` no longer appears in the entity registry
3. Confirm all pre-existing `device_tracker` entities still function normally

## Notes

The Lovelace card at `lovelace/peplink-card.yaml` is a template for manual installation — copy its contents into a Markdown card in your dashboard. It is not auto-loaded by HACS.